### PR TITLE
refactor: update message constructor

### DIFF
--- a/autogpt/self_improve/plugin_processor.py
+++ b/autogpt/self_improve/plugin_processor.py
@@ -39,8 +39,8 @@ def generate_diff(context: str) -> str:
     prompt = ChatSequence.for_model(
         cfg.smart_llm,
         [
-            Message.system(system_prompt),
-            Message.user(context),
+            Message("system", system_prompt),
+            Message("user", context),
         ],
     )
 


### PR DESCRIPTION
## Summary
- fix plugin processor message init calls

## Testing
- `python -m py_compile autogpt/self_improve/plugin_processor.py`
- `pytest` *(fails: No module named 'mlx')*

------
https://chatgpt.com/codex/tasks/task_e_688f1571cd4c832f9615c56d44d8e25c