### PR TITLE
Ensure thread-safe DatabaseManager connection

### DIFF
--- a/autogpt/self_improve/database.py
+++ b/autogpt/self_improve/database.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sqlite3
 from datetime import datetime
 from pathlib import Path
+from threading import Lock
 from typing import Iterable, Tuple
 
 from autogpt.event_bus import EventBus
@@ -16,13 +17,17 @@ class DatabaseManager:
     def __init__(self, db_path: Path | str, event_bus: EventBus | None = None) -> None:
         self.db_path = Path(db_path)
         self.event_bus = event_bus
-        self.connection = sqlite3.connect(self.db_path)
+        # Allow the connection to be shared across threads. We'll protect access
+        # with a lock to avoid concurrent writes or reads on the same connection.
+        self.connection = sqlite3.connect(self.db_path, check_same_thread=False)
+        self._lock = Lock()
         self.init_db()
 
     def init_db(self) -> None:
-        cur = self.connection.cursor()
-        cur.execute(
-            """
+        with self._lock:
+            cur = self.connection.cursor()
+            cur.execute(
+                """
             CREATE TABLE IF NOT EXISTS errors (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 timestamp TEXT,
@@ -30,9 +35,9 @@ class DatabaseManager:
                 traceback TEXT
             )
             """
-        )
-        cur.execute(
-            """
+            )
+            cur.execute(
+                """
             CREATE TABLE IF NOT EXISTS profiles (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 timestamp TEXT,
@@ -40,9 +45,9 @@ class DatabaseManager:
                 duration REAL
             )
             """
-        )
-        cur.execute(
-            """
+            )
+            cur.execute(
+                """
             CREATE TABLE IF NOT EXISTS executions (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 timestamp TEXT,
@@ -50,9 +55,9 @@ class DatabaseManager:
                 result TEXT
             )
             """
-        )
-        cur.execute(
-            """
+            )
+            cur.execute(
+                """
             CREATE TABLE IF NOT EXISTS profiles_detailed (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 timestamp TEXT,
@@ -62,25 +67,26 @@ class DatabaseManager:
                 cumtime REAL
             )
             """
-        )
-        cur.execute(
-            """
+            )
+            cur.execute(
+                """
             CREATE TABLE IF NOT EXISTS patch_attempts (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 timestamp TEXT,
                 success INTEGER
             )
             """
-        )
-        self.connection.commit()
+            )
+            self.connection.commit()
 
     def log_error(self, exception: str, traceback_str: str) -> None:
-        cur = self.connection.cursor()
-        cur.execute(
-            "INSERT INTO errors(timestamp, exception, traceback) VALUES (?, ?, ?)",
-            (datetime.utcnow().isoformat(), exception, traceback_str),
-        )
-        self.connection.commit()
+        with self._lock:
+            cur = self.connection.cursor()
+            cur.execute(
+                "INSERT INTO errors(timestamp, exception, traceback) VALUES (?, ?, ?)",
+                (datetime.utcnow().isoformat(), exception, traceback_str),
+            )
+            self.connection.commit()
         if self.event_bus:
             self.event_bus.emit(
                 "error",
@@ -88,12 +94,13 @@ class DatabaseManager:
             )
 
     def log_profile(self, name: str, duration: float) -> None:
-        cur = self.connection.cursor()
-        cur.execute(
-            "INSERT INTO profiles(timestamp, name, duration) VALUES (?, ?, ?)",
-            (datetime.utcnow().isoformat(), name, duration),
-        )
-        self.connection.commit()
+        with self._lock:
+            cur = self.connection.cursor()
+            cur.execute(
+                "INSERT INTO profiles(timestamp, name, duration) VALUES (?, ?, ?)",
+                (datetime.utcnow().isoformat(), name, duration),
+            )
+            self.connection.commit()
         if self.event_bus:
             self.event_bus.emit(
                 "profile",
@@ -101,12 +108,13 @@ class DatabaseManager:
             )
 
     def log_execution(self, description: str, result: str) -> None:
-        cur = self.connection.cursor()
-        cur.execute(
-            "INSERT INTO executions(timestamp, description, result) VALUES (?, ?, ?)",
-            (datetime.utcnow().isoformat(), description, result),
-        )
-        self.connection.commit()
+        with self._lock:
+            cur = self.connection.cursor()
+            cur.execute(
+                "INSERT INTO executions(timestamp, description, result) VALUES (?, ?, ?)",
+                (datetime.utcnow().isoformat(), description, result),
+            )
+            self.connection.commit()
         if self.event_bus:
             self.event_bus.emit(
                 "execution",
@@ -116,12 +124,13 @@ class DatabaseManager:
     def log_profile_detail(
         self, name: str, function: str, ncalls: int, cumtime: float
     ) -> None:
-        cur = self.connection.cursor()
-        cur.execute(
-            "INSERT INTO profiles_detailed(timestamp, name, function, ncalls, cumtime) VALUES (?, ?, ?, ?, ?)",
-            (datetime.utcnow().isoformat(), name, function, ncalls, cumtime),
-        )
-        self.connection.commit()
+        with self._lock:
+            cur = self.connection.cursor()
+            cur.execute(
+                "INSERT INTO profiles_detailed(timestamp, name, function, ncalls, cumtime) VALUES (?, ?, ?, ?, ?)",
+                (datetime.utcnow().isoformat(), name, function, ncalls, cumtime),
+            )
+            self.connection.commit()
         if self.event_bus:
             self.event_bus.emit(
                 "profile_detail",
@@ -134,37 +143,54 @@ class DatabaseManager:
             )
 
     def get_errors(self) -> Iterable[Tuple]:
-        cur = self.connection.cursor()
-        return cur.execute("SELECT timestamp, exception, traceback FROM errors")
+        with self._lock:
+            cur = self.connection.cursor()
+            result = cur.execute(
+                "SELECT timestamp, exception, traceback FROM errors"
+            ).fetchall()
+        return result
 
     def get_profiles(self) -> Iterable[Tuple]:
-        cur = self.connection.cursor()
-        return cur.execute("SELECT timestamp, name, duration FROM profiles")
+        with self._lock:
+            cur = self.connection.cursor()
+            result = cur.execute(
+                "SELECT timestamp, name, duration FROM profiles"
+            ).fetchall()
+        return result
 
     def get_profile_details(self) -> Iterable[Tuple]:
-        cur = self.connection.cursor()
-        return cur.execute(
-            "SELECT timestamp, name, function, ncalls, cumtime FROM profiles_detailed"
-        )
+        with self._lock:
+            cur = self.connection.cursor()
+            result = cur.execute(
+                "SELECT timestamp, name, function, ncalls, cumtime FROM profiles_detailed"
+            ).fetchall()
+        return result
 
     def get_hotspots(self, threshold: float) -> Iterable[Tuple]:
-        cur = self.connection.cursor()
-        return cur.execute(
-            "SELECT function, SUM(cumtime) as total FROM profiles_detailed GROUP BY function HAVING total > ?",
-            (threshold,),
-        )
+        with self._lock:
+            cur = self.connection.cursor()
+            result = cur.execute(
+                "SELECT function, SUM(cumtime) as total FROM profiles_detailed GROUP BY function HAVING total > ?",
+                (threshold,),
+            ).fetchall()
+        return result
 
     def get_executions(self) -> Iterable[Tuple]:
-        cur = self.connection.cursor()
-        return cur.execute("SELECT timestamp, description, result FROM executions")
+        with self._lock:
+            cur = self.connection.cursor()
+            result = cur.execute(
+                "SELECT timestamp, description, result FROM executions"
+            ).fetchall()
+        return result
 
     def log_patch_attempt(self, success: bool) -> None:
-        cur = self.connection.cursor()
-        cur.execute(
-            "INSERT INTO patch_attempts(timestamp, success) VALUES (?, ?)",
-            (datetime.utcnow().isoformat(), int(success)),
-        )
-        self.connection.commit()
+        with self._lock:
+            cur = self.connection.cursor()
+            cur.execute(
+                "INSERT INTO patch_attempts(timestamp, success) VALUES (?, ?)",
+                (datetime.utcnow().isoformat(), int(success)),
+            )
+            self.connection.commit()
         if self.event_bus:
             self.event_bus.emit(
                 "patch_attempt",
@@ -172,8 +198,10 @@ class DatabaseManager:
             )
 
     def get_last_patch_attempts(self, count: int) -> Iterable[Tuple]:
-        cur = self.connection.cursor()
-        return cur.execute(
-            "SELECT success FROM patch_attempts ORDER BY id DESC LIMIT ?",
-            (count,),
-        )
+        with self._lock:
+            cur = self.connection.cursor()
+            result = cur.execute(
+                "SELECT success FROM patch_attempts ORDER BY id DESC LIMIT ?",
+                (count,),
+            ).fetchall()
+        return result


### PR DESCRIPTION
## Summary
- allow SQLite connections in DatabaseManager to be shared across threads
- serialize database access with a threading lock and return list-based query results

## Testing
- `pre-commit run --files autogpt/self_improve/database.py` *(fails: ImportError while loading conftest '/workspace/AutoGPT-0.4.7/tests/conftest.py'...)*

------
https://chatgpt.com/codex/tasks/task_e_688f158001c4832f98bf851d9e3c8768