### PR TITLE
refactor: improve JSON extraction and add tests

### DIFF
--- a/autogpt/json_utils/utilities.py
+++ b/autogpt/json_utils/utilities.py
@@ -18,11 +18,18 @@ def extract_dict_from_response(response_content: str) -> dict[str, Any]:
         # Discard the first and last ```, then re-join in case the response naturally included ```
         response_content = "```".join(response_content.split("```")[1:-1])
 
-    # response content comes from OpenAI as a Python `str(content_dict)`, literal_eval reverses this
+    # Try to parse the string using json.loads first.
+    try:
+        return json.loads(response_content)
+    except json.JSONDecodeError as e_json:
+        logger.info(f"Error parsing JSON response with json.loads {e_json}")
+        logger.debug(f"Invalid JSON received in response: {response_content}")
+
+    # If json.loads fails, fall back to ast.literal_eval for Python dict strings
     try:
         return ast.literal_eval(response_content)
     except BaseException as e:
-        logger.info(f"Error parsing JSON response with literal_eval {e}")
+        logger.info(f"Error parsing JSON response with ast.literal_eval {e}")
         logger.debug(f"Invalid JSON received in response: {response_content}")
         raise ValueError(f"Error parsing JSON response: {e}") from e
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,7 @@
 import os
 from unittest.mock import patch
 
+import json
 import pytest
 import requests
 
@@ -194,14 +195,21 @@ def test_validate_json_invalid(invalid_json_response, config: Config):
     assert errors is not None
 
 
-def test_extract_json_from_response(valid_json_response: dict):
+def test_extract_dict_from_response_json_string(valid_json_response: dict):
+    emulated_response_from_openai = json.dumps(valid_json_response)
+    assert (
+        extract_dict_from_response(emulated_response_from_openai) == valid_json_response
+    )
+
+
+def test_extract_dict_from_response_python_dict_string(valid_json_response: dict):
     emulated_response_from_openai = str(valid_json_response)
     assert (
         extract_dict_from_response(emulated_response_from_openai) == valid_json_response
     )
 
 
-def test_extract_json_from_response_wrapped_in_code_block(valid_json_response: dict):
+def test_extract_dict_from_response_wrapped_in_code_block(valid_json_response: dict):
     emulated_response_from_openai = "```" + str(valid_json_response) + "```"
     assert (
         extract_dict_from_response(emulated_response_from_openai) == valid_json_response


### PR DESCRIPTION
## Summary
- try `json.loads` before `ast.literal_eval` when parsing LLM responses and log failures separately
- add tests for both pure JSON strings and Python dict strings, including code-block wrapped input

## Testing
- `pytest tests/unit/test_utils.py::test_extract_dict_from_response_json_string tests/unit/test_utils.py::test_extract_dict_from_response_python_dict_string tests/unit/test_utils.py::test_extract_dict_from_response_wrapped_in_code_block -q`


------
https://chatgpt.com/codex/tasks/task_e_688f297e61e8832fb26577a654714063